### PR TITLE
Fix margin-left

### DIFF
--- a/src/components/encoding/Base64Encode.js
+++ b/src/components/encoding/Base64Encode.js
@@ -92,7 +92,7 @@ const Base64Encode = () => {
 						<CopyOutlined /> Copy
 					</Button>
 				</Clipboard>
-				<Button type='link' danger style={{ marginBottom: 10, marginTop: 15 }} onClick={() => setOutput('')}>
+				<Button type='link' danger style={{ marginBottom: 10, marginTop: 15, marginLeft: 15 }} onClick={() => setOutput('')}>
 					<ClearOutlined /> Clear
 				</Button>
 			</div>


### PR DESCRIPTION
In "Base64 Encoder / Decoder" page, "Clear" button is missing margin-left.

![image](https://user-images.githubusercontent.com/12462188/104096209-58e8ea80-529b-11eb-84be-95dca2a8b4be.png)
